### PR TITLE
uppercase titles

### DIFF
--- a/src/components/Empty.tsx
+++ b/src/components/Empty.tsx
@@ -21,7 +21,7 @@ const styles = StyleSheet.create({
     text: {
         textAlign: 'center',
         color: colors.darkGrey1A,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         fontSize: 16,
         lineHeight: 21,
         letterSpacing: 0.5,

--- a/src/components/typography/CardTitle.tsx
+++ b/src/components/typography/CardTitle.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Text, TextStyle } from 'react-native';
+import { colors, typography } from '@styles';
+import { FontWeight, TextTransform } from '@styles/typography';
+
+type TextColor = 'white' | 'black' | string;
+
+interface TitleProps {
+    fontSize?: number;
+    fonts?: FontWeight;
+    textTransform?: TextTransform;
+    styleProps?: TextStyle;
+    textColor?: TextColor;
+    numberOfLines?: number | undefined;
+    ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip' | undefined;
+}
+
+const CardTitle: React.FC<TitleProps> = ({
+    children,
+    fontSize = 16,
+    fonts = 'medium',
+    textTransform = 'uppercase',
+    textColor = 'white',
+    styleProps,
+    numberOfLines,
+    ellipsizeMode,
+}) => {
+    if (textColor === 'white') {
+        textColor = colors.white;
+    }
+    if (textColor === 'black') {
+        textColor = colors.darkGrey1A;
+    }
+
+    return (
+        <Text
+            {...{ numberOfLines, ellipsizeMode }}
+            style={[
+                {
+                    color: textColor,
+                    fontFamily: typography[fonts],
+                    fontSize,
+                    textTransform,
+                    letterSpacing: 0.08,
+                    lineHeight: 21,
+                },
+                styleProps,
+            ]}
+        >
+            {children}
+        </Text>
+    );
+};
+
+export default CardTitle;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,2 +1,8 @@
-export const normal = 'DINPro-Regular';
+export const light = 'DINPro-Light';
+export const regular = 'DINPro-Regular';
+export const medium = 'DINPro-Medium';
 export const bold = 'DINPro-Bold';
+export const black = 'DINPro-Black';
+
+export type FontWeight = 'light' | 'regular' | 'medium' | 'bold' | 'black';
+export type TextTransform = 'none' | 'capitalize' | 'uppercase' | 'lowercase' | undefined;

--- a/src/views/EventFilterView/Card.tsx
+++ b/src/views/EventFilterView/Card.tsx
@@ -72,13 +72,13 @@ const styles = StyleSheet.create({
         marginBottom: 12,
         width: '90%',
         color: colors.white,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
     },
     location: {
         fontSize: 14,
         lineHeight: 18,
         color: colors.white,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
     },
     bottom: {
         flexDirection: 'column',

--- a/src/views/EventFilterView/Label.tsx
+++ b/src/views/EventFilterView/Label.tsx
@@ -27,6 +27,6 @@ const styles = StyleSheet.create({
         fontSize: 14,
         lineHeight: 18,
         color: colors.white,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
     },
 });

--- a/src/views/EventListView/component/Card.tsx
+++ b/src/views/EventListView/component/Card.tsx
@@ -6,6 +6,7 @@ import { colors, typography, opacity } from '@styles';
 import { IconButtons } from './IconButtons';
 import { EventItem } from '../types';
 import { dateTimeUtils } from '@utils';
+import CardTitle from '@components/typography/CardTitle';
 
 interface CardProps {
     item: EventItem;
@@ -26,7 +27,7 @@ export const Card: React.FC<CardProps> = ({ item, backgroundColor, onFavourite, 
                     </View>
                 )}
                 <View style={[styles.bottomContainer, { backgroundColor }]}>
-                    <Text style={styles.title}>{item.title}</Text>
+                    <CardTitle styleProps={{ marginBottom: 12 }}>{item.title} </CardTitle>
                     <Text style={styles.location}>{item.locationTitle}</Text>
                     <View style={styles.labels}>
                         <Label title={dateTimeUtils.formatDateDay(item.date)} iconType={IconType.Calendar} />
@@ -56,16 +57,8 @@ const styles = StyleSheet.create({
     bottomContainer: {
         padding: 16,
     },
-    title: {
-        color: colors.white,
-        fontFamily: typography.normal,
-        fontWeight: '500',
-        fontSize: 16,
-        lineHeight: 21,
-        marginBottom: 12,
-    },
     location: {
-        fontFamily: typography.normal,
+        fontFamily: typography.regular,
         fontSize: 14,
         lineHeight: 18,
         color: colors.white,

--- a/src/views/EventListView/component/Label.tsx
+++ b/src/views/EventListView/component/Label.tsx
@@ -23,9 +23,8 @@ const styles = StyleSheet.create({
         paddingBottom: 12,
     },
     title: {
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         paddingLeft: 10,
-        fontWeight: '500',
         fontSize: 14,
         lineHeight: 18,
         color: colors.white,

--- a/src/views/EventMapView/component/EventCard.tsx
+++ b/src/views/EventMapView/component/EventCard.tsx
@@ -6,6 +6,7 @@ import { IconButtons } from './IconButtons';
 import { dateTimeUtils } from '@utils';
 import { colors, typography } from '@styles';
 import { AnyType } from '@domain/AnyType';
+import CardTitle from '@components/typography/CardTitle';
 
 interface EventDescriptionProps {
     item: EventItem;
@@ -30,9 +31,10 @@ export const EventCard = ({
         <View style={[styles.slide]}>
             <View style={[styles.slideInnerContainer, { backgroundColor }]}>
                 <TouchableOpacity onPress={onReadMore}>
-                    <Text style={styles.eventTitle} numberOfLines={3} ellipsizeMode="tail">
+                    <CardTitle styleProps={{ marginBottom: 12 }} numberOfLines={3} ellipsizeMode="tail">
                         {item.title}
-                    </Text>
+                    </CardTitle>
+
                     <Text style={styles.eventLocation} numberOfLines={2} ellipsizeMode="tail">
                         {item.locationTitle}
                     </Text>
@@ -75,20 +77,13 @@ const styles = StyleSheet.create({
         paddingHorizontal: 16,
         flex: 1,
     },
-    eventTitle: {
-        fontSize: 16,
-        lineHeight: 21,
-        color: colors.white,
-        fontFamily: typography.bold,
-        marginBottom: 12,
-    },
     row: {
         flexDirection: 'row',
         justifyContent: 'space-between',
         alignItems: 'flex-end',
     },
     eventLocation: {
-        fontFamily: typography.normal,
+        fontFamily: typography.regular,
         fontSize: 14,
         lineHeight: 18,
         color: colors.white,
@@ -99,7 +94,7 @@ const styles = StyleSheet.create({
         lineHeight: 18,
         color: colors.white,
         marginLeft: 10,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
     },
     eventiconLabel: {
         display: 'flex',

--- a/src/views/MarkdownEvent/component/Label.tsx
+++ b/src/views/MarkdownEvent/component/Label.tsx
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
         paddingBottom: 12,
     },
     title: {
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         paddingLeft: 10,
         fontWeight: '500',
         fontSize: 14,

--- a/src/views/MarkdownEvent/component/index.tsx
+++ b/src/views/MarkdownEvent/component/index.tsx
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
 
 const markdownstyles = StyleSheet.create({
     text: {
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         fontSize: 16,
         lineHeight: 18,
     },

--- a/src/views/NewsListView/component/Card.tsx
+++ b/src/views/NewsListView/component/Card.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
-import { colors, opacity } from '@styles';
+import { colors, opacity, typography } from '@styles';
 import { dateTimeUtils } from '@utils';
 import { Image } from '@components';
 import { NewsItem } from '../types';
 import { IconButtons } from './IconButtons';
+import CardTitle from '@components/typography/CardTitle';
 
 interface CardProps {
     item: NewsItem;
@@ -23,8 +24,8 @@ const Card: React.FC<CardProps> = ({ item, backgroundColor, onNavigate, onFavour
                 </View>
             )}
             <View style={[styles.lowerContainer, { backgroundColor }]}>
-                <Text style={styles.dateText}> {dateTimeUtils.formatDate(item.date)}</Text>
-                <Text style={styles.titleText}> {item.title}</Text>
+                <Text style={styles.dateText}>{dateTimeUtils.formatDate(item.date)}</Text>
+                <CardTitle styleProps={{ marginBottom: 16 }}>{item.title}</CardTitle>
                 <IconButtons onShare={onShare} isFavourite={item.isFavourite} onFavourite={onFavourite} />
             </View>
         </TouchableOpacity>
@@ -59,14 +60,8 @@ const styles = StyleSheet.create({
     },
     dateText: {
         color: colors.white,
-        fontWeight: '500',
+        fontFamily: typography.medium,
         fontSize: 14,
         marginBottom: 8,
-    },
-    titleText: {
-        color: colors.white,
-        fontWeight: '500',
-        fontSize: 16,
-        marginBottom: 16,
     },
 });

--- a/src/views/SearchBy.tsx
+++ b/src/views/SearchBy.tsx
@@ -36,7 +36,7 @@ const styles = StyleSheet.create({
         justifyContent: 'center',
     },
     text: {
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         fontSize: 16,
         lineHeight: 21,
         color: colors.darkGrey1A,

--- a/src/views/UserCategoryView/Card.tsx
+++ b/src/views/UserCategoryView/Card.tsx
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
     },
     cardExtraText: {
         color: colors.white,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         fontSize: 14,
         lineHeight: 18,
         letterSpacing: 0.25,

--- a/src/views/UserSettings/index.tsx
+++ b/src/views/UserSettings/index.tsx
@@ -82,7 +82,7 @@ export const userSettingStyles = StyleSheet.create({
     },
     cardExtraText: {
         color: colors.darkGrey1A,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
         fontSize: 14,
         lineHeight: 18,
         letterSpacing: 0.25,

--- a/src/views/VideoView/Card.tsx
+++ b/src/views/VideoView/Card.tsx
@@ -3,6 +3,7 @@ import { Text, View, StyleSheet } from 'react-native';
 import { VideoData } from './types';
 import { typography } from '@styles';
 import { Image } from '@components';
+import CardTitle from '@components/typography/CardTitle';
 
 interface CardProps {
     item: VideoData;
@@ -16,9 +17,7 @@ export class Card extends React.Component<CardProps> {
                 <View style={styles.videoContainer}>
                     <Image height={180} source={{ uri: item.video }} style={styles.image} />
                 </View>
-                <View>
-                    <Text style={styles.title}>{item.title}</Text>
-                </View>
+                <CardTitle styleProps={{ paddingVertical: 12 }}>{item.title}</CardTitle>
                 <View>
                     <Text style={styles.statistics}>{item.statistics}</Text>
                 </View>
@@ -39,13 +38,8 @@ const styles = StyleSheet.create({
         width: '100%',
         height: 180,
     },
-    title: {
-        fontSize: 16,
-        fontFamily: typography.bold,
-        paddingVertical: 12,
-    },
     statistics: {
         fontSize: 14,
-        fontFamily: typography.normal,
+        fontFamily: typography.medium,
     },
 });


### PR DESCRIPTION
- added missing fonts
- now available fonts and approximate css equivalents:
    - light (font weight: ~200)
    - regular (font weight: ~300)
    - medium (font weight: ~500)
    - bold (font weight: ~700)
    - black (font weight: ~900)
- did some adjustments to to Feed cards to use added fonts
- added separate component called CardTitle `components>typography>CardTitle.tsx` with default props , which now is being used in all Feed cards, to change all cards back to lowecase letters now will be easier since only once component needs to be changed. And if some adjustments needs to be made in particular view, then appropriate prop can be passed to CardTitle, ...or new prop can be added.